### PR TITLE
libpng compilation fix

### DIFF
--- a/vtorcs-RL-color/src/libs/tgfclient/img.cpp
+++ b/vtorcs-RL-color/src/libs/tgfclient/img.cpp
@@ -98,7 +98,7 @@ GfImgReadPng(const char *filename, int *widthp, int *heightp, float screen_gamma
 		return (unsigned char *)NULL;
 	}
 	
-	if (setjmp(png_ptr->jmpbuf))
+	if (setjmp(png_jmpbuf(png_ptr)))
 	{
 		/* Free all of the memory associated with the png_ptr and info_ptr */
 		png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
@@ -229,7 +229,7 @@ GfImgWritePng(unsigned char *img, const char *filename, int width, int height)
 		return -1;
 	}
 	
-	if (setjmp(png_ptr->jmpbuf)) {    
+	if (setjmp(png_jmpbuf(png_ptr))) {    
 		png_destroy_write_struct(&png_ptr, &info_ptr);
 		fclose(fp);
 		return -1;

--- a/vtorcs-RL-color/src/misc/png2jpg/png2jpg.c
+++ b/vtorcs-RL-color/src/misc/png2jpg/png2jpg.c
@@ -90,7 +90,7 @@ ImgReadPng(FILE *fp, int *widthp, int *heightp, float screen_gamma)
 	    return (unsigned char *)NULL;
 	}
    
-    if (setjmp(png_ptr->jmpbuf))
+    if (setjmp(png_jmpbuf(png_ptr)))
 	{
 	    /* Free all of the memory associated with the png_ptr and info_ptr */
 	    png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);


### PR DESCRIPTION
Got compilation error on make:

> img.cpp: In function 'unsigned char\* GfImgReadPng(const char_, int_, int_, float)':
> img.cpp:101:20: error: invalid use of incomplete type 'png_struct {aka struct png_struct_def}'
>   if (setjmp(png_ptr->jmpbuf))
>                     ^
> In file included from img.cpp:31:0:
> /usr/include/png.h:595:16: error: forward declaration of 'png_struct {aka struct png_struct_def}'
>  typedef struct png_struct_def png_struct;
>                 ^
> In file included from /usr/include/pngconf.h:72:0,
>                  from /usr/include/png.h:485,
>                  from img.cpp:31:
> img.cpp: In function 'int GfImgWritePng(unsigned char_, const char*, int, int)':
> img.cpp:232:20: error: invalid use of incomplete type 'png_struct {aka struct png_struct_def}'
>   if (setjmp(png_ptr->jmpbuf)) {
>                     ^
> In file included from img.cpp:31:0:
> /usr/include/png.h:595:16: error: forward declaration of 'png_struct {aka struct png_struct_def}'
>  typedef struct png_struct_def png_struct;

Seems like new versions of libpng provide access to png_struct only via functions, fixed it.
png2jpg.c contained the same code, so I replaced it.
