### PR TITLE
fix argument to isnan() in simu.cpp

### DIFF
--- a/vtorcs-RL-color/src/modules/simu/simuv2/simu.cpp
+++ b/vtorcs-RL-color/src/modules/simu/simuv2/simu.cpp
@@ -61,13 +61,13 @@ ctrlCheck(tCar *car)
     if (isnan(car->ctrl->brakeCmd) || isinf(car->ctrl->brakeCmd)) car->ctrl->brakeCmd = 0;
     if (isnan(car->ctrl->clutchCmd) || isinf(car->ctrl->clutchCmd)) car->ctrl->clutchCmd = 0;
     if (isnan(car->ctrl->steer) || isinf(car->ctrl->steer)) car->ctrl->steer = 0;
-    if (isnan(car->ctrl->gear) || isinf(car->ctrl->gear)) car->ctrl->gear = 0;
+    if (isnan(static_cast<float>(car->ctrl->gear)) || isinf(static_cast<float>(car->ctrl->gear))) car->ctrl->gear = 0;
 #else
     if (isnan(car->ctrl->accelCmd)) car->ctrl->accelCmd = 0;
     if (isnan(car->ctrl->brakeCmd)) car->ctrl->brakeCmd = 0;
     if (isnan(car->ctrl->clutchCmd)) car->ctrl->clutchCmd = 0;
     if (isnan(car->ctrl->steer)) car->ctrl->steer = 0;
-    if (isnan(car->ctrl->gear)) car->ctrl->gear = 0;
+    if (isnan(static_cast<float>(car->ctrl->gear))) car->ctrl->gear = 0;
 #endif
 
     /* When the car is broken try to send it on the track side */


### PR DESCRIPTION
Hi, I was trying to compile vtorcs-rgb on Ubuntu 16.04 but encountered an error about argument to the `isnan()` function. Apparently it expects a float, so I quickly tried casting `car->ctrl-gear` to float to avoid compile errors and it compiled just fine for me.